### PR TITLE
Traces inbound requests, so that there's always a trace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,10 @@ dependencies {
 	compile('org.springframework.boot:spring-boot-starter')
 	compile('org.springframework.boot:spring-boot-starter-web')
 	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-	compile group: 'io.zipkin.brave', name: 'brave', version: '4.3.0'
-	compile group: 'io.zipkin.brave', name: 'brave-context-slf4j', version: '4.3.0'
-	compile group: 'io.zipkin.brave', name: 'brave-instrumentation-httpclient', version: '4.3.0'
+	compile group: 'io.zipkin.brave', name: 'brave', version: '4.3.1'
+	compile group: 'io.zipkin.brave', name: 'brave-context-slf4j', version: '4.3.1'
+	compile group: 'io.zipkin.brave', name: 'brave-instrumentation-httpclient', version: '4.3.1'
+	compile group: 'io.zipkin.brave', name: 'brave-instrumentation-spring-webmvc', version: '4.3.1'
 	compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 	compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
 	testCompile('org.springframework.boot:spring-boot-starter-test')

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -2,46 +2,72 @@ package com.example.demo;
 
 import brave.Tracing;
 import brave.context.slf4j.MDCCurrentTraceContext;
+import brave.http.HttpTracing;
 import brave.httpclient.TracingHttpClientBuilder;
+import brave.spring.webmvc.TracingHandlerInterceptor;
+import java.io.IOException;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.IOException;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @SpringBootApplication
 @RestController
 public class DemoApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
-	}
+  /** Controls aspects of tracing such as the name that shows up in the UI */
+  @Bean Tracing tracing() {
+    return Tracing.newBuilder()
+        .localServiceName("hello")
+        .currentTraceContext(MDCCurrentTraceContext.create())
+        .build();
+  }
 
-	private static Logger logger = org.slf4j.LoggerFactory.getLogger(DemoApplication.class);
+  /** Customize span names and tag policy here */
+  @Bean HttpTracing httpTracing(Tracing tracing) {
+    return HttpTracing.create(tracing);
+  }
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
-	public String index() throws IOException {
-		Tracing tracing = Tracing.newBuilder()
-				.localServiceName("helloClient")
-				.currentTraceContext(MDCCurrentTraceContext.create())
-//                .reporter(Reporter.NOOP)
-				.build();
+  /** Makes sure a trace is started for requests to the rest controller */
+  @Bean WebMvcConfigurerAdapter traceIncomingRequests(HttpTracing httpTracing) {
+    return new WebMvcConfigurerAdapter() {
+      @Override public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(TracingHandlerInterceptor.create(httpTracing));
+      }
+    };
+  }
 
-		CloseableHttpClient httpClient = TracingHttpClientBuilder.create(tracing).build();
+  /** Makes sure a trace is continued on outgoing requests */
+  @Bean CloseableHttpClient traceOutgoingRequests(HttpTracing httpTracing) {
+    return TracingHttpClientBuilder.create(httpTracing).build();
+  }
 
-		HttpPost httpPost = new HttpPost("http://localhost:8080");
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
 
-		logger.info("About to submit a request");
-		httpClient.execute(httpPost);
+  private static Logger logger = org.slf4j.LoggerFactory.getLogger(DemoApplication.class);
 
-		String traceId = MDC.get("traceId");
+  @Autowired CloseableHttpClient httpClient;
 
-		return "traceId: " + traceId;
-	}
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  public String index() throws IOException {
+    HttpPost httpPost = new HttpPost("http://localhost:8080");
+
+    logger.info("About to submit a request");
+    httpClient.execute(httpPost);
+
+    String traceId = MDC.get("traceId");
+
+    return "traceId: " + traceId;
+  }
 }


### PR DESCRIPTION
Before, there was a log statement made outside the scope of a trace.
This was because there was no trace started beforehand. This adds
inbound tracing so that there's a trace in scope for the log statement.

See https://github.com/openzipkin/brave/issues/399 for auto-configuration